### PR TITLE
Refactor AboutMeSection; add .claude settings

### DIFF
--- a/www/.claude/settings.local.json
+++ b/www/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(powershell *)",
+      "Read(//d/Projects/Personal/JenuelDev/www/.claude//**)",
+      "Read(//d/Projects/Personal/JenuelDev/www/.claude/**)",
+      "Bash(powershell.exe *)",
+      "Bash(whoami *)",
+      "Bash(systeminfo)",
+      "Bash(tasklist *)",
+      "Bash(wmic os *)",
+      "Bash('\"$SoundPath')"
+    ]
+  }
+}

--- a/www/src/components/AboutMe/ABoutMeSection.vue
+++ b/www/src/components/AboutMe/ABoutMeSection.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import SvgDecoration from "./../SvgDecoration/SvgDecoration.vue";
 import YoutubeButton from "@/components/Button/YoutubeButton.vue";
 import { Icon } from "@iconify/vue";
 
-const yearCount = () => {
-    return new Date().getFullYear() - 2018;
-};
+const yearCount = computed(() => new Date().getFullYear() - 2018);
 </script>
 <template>
     <section id="about-me" class="mx-auto mb-100px flex flex-col items-center max-w-900px visible px-10px lg:mt-130px">
@@ -13,7 +12,7 @@ const yearCount = () => {
             <div class="lg:order-1 order-2">
                 <div class="lg:text-right text-center max-w-500px">
                     <div>
-                        <h3 class="md:text-3xl text-2xl font-500 mb-2">Hi! I’m Jenuel, & I'm a</h3>
+                        <p class="md:text-3xl text-2xl font-500 mb-2">Hi, I’m Jenuel — a</p>
                         <h1 class="md:text-5xl text-3xl font-600 text-[var(--primary)] mb-2">Software Developer</h1>
                         <h2 class="md:text-3xl text-2xl text-[var(--lightestSlate)] mb-2">
                             I create web apps that are engaging, accessible and scalable.
@@ -46,25 +45,23 @@ const yearCount = () => {
             </div>
             <div class="lg:order-2 order-1 z-50 relative">
                 <div class="overflow-hidden rounded-lg">
-                    <div style="position: relative; overflow: hidden">
-                        <img
-                            class="max-w-300px w-[100%] w-[300px] profile-picture-style"
-                            loading="eager"
-                            fetchpriority="high"
-                            decoding="async"
-                            width="300px"
-                            height="300px"
-                            src="/profile_image-640.webp"
-                            srcset="
-                                /profile_image-480.webp  480w,
-                                /profile_image-640.webp  640w,
-                                /profile_image-768.webp  768w,
-                                /profile_image.webp     1024w
-                            "
-                            sizes="(max-width: 768px) 280px, 300px"
-                            alt="Jenuel Ganawed - Profile Picture"
-                        />
-                    </div>
+                    <img
+                        class="max-w-300px w-[300px] profile-picture-style"
+                        loading="eager"
+                        fetchpriority="high"
+                        decoding="async"
+                        width="300"
+                        height="300"
+                        src="/profile_image-640.webp"
+                        srcset="
+                            /profile_image-480.webp  480w,
+                            /profile_image-640.webp  640w,
+                            /profile_image-768.webp  768w,
+                            /profile_image.webp     1024w
+                        "
+                        sizes="(max-width: 768px) 280px, 300px"
+                        alt="Jenuel Ganawed - Profile Picture"
+                    />
                 </div>
             </div>
             <SvgDecoration
@@ -86,7 +83,7 @@ const yearCount = () => {
                 introduced me to software development and set the direction for the work I do today.
             </p>
             <p class="mb-30px">
-                With over <strong>{{ yearCount() }} years of experience as a software developer</strong>, I have grown
+                With over <strong>{{ yearCount }} years of experience as a software developer</strong>, I have grown
                 in fast-paced environments, collaborated with talented engineers, and contributed to impactful projects.
             </p>
             <p class="mb-30px">


### PR DESCRIPTION
Add a new www/.claude/settings.local.json for local assistant permissions. Refactor AboutMeSection.vue: import Vue's computed, convert yearCount from a function to a computed value and update template bindings accordingly, replace an h3 with a semantic p for the intro line, and simplify the profile image markup (remove extra wrapper, normalize width/height attributes and classes). These changes simplify reactivity, clean up markup, and include local config for .claude.