### PR TITLE
Refactor theme script and trim experiences

### DIFF
--- a/blog/src/components/ThemeScript.astro
+++ b/blog/src/components/ThemeScript.astro
@@ -3,14 +3,12 @@
 // Must be placed first in <head>
 ---
 <script is:inline>
-  (function() {
+  function applyTheme() {
     var DARK_ACCENTS = ['greenLight', 'yellowOrange', 'underTheSea', 'NightBurns'];
-    var LIGHT_ACCENTS = ['lightBurn', 'brightMind'];
 
     var accent = localStorage.getItem('accent') || 'greenLight';
     var isDarkAccent = DARK_ACCENTS.indexOf(accent) !== -1;
 
-    // For dark accents, always dark. For light accents, respect light/dark pref.
     var isDark;
     if (isDarkAccent) {
       isDark = true;
@@ -25,5 +23,8 @@
       document.documentElement.classList.remove('dark');
     }
     document.documentElement.setAttribute('data-accent', accent);
-  })();
+  }
+
+  applyTheme();
+  document.addEventListener('astro:after-swap', applyTheme);
 </script>

--- a/www/src/constant/experiences/index.ts
+++ b/www/src/constant/experiences/index.ts
@@ -5,10 +5,8 @@ const vocphone = {
     workStart: 'Nov. 2021',
     workUntil: '<span class="present-work">Present</span>',
     des: [
-        'Led the end-to-end design and development of selected external web and backend projects aligned with user stories and business goals.',
         'Collaborate with product owners and stakeholders to translate requirements into clear technical tasks and delivery milestones.',
         'Architect, implement, and review features with a focus on scalability, performance, and long-term maintainability.',
-        'Mentor teammates, share best practices, and help standardize tools, patterns, and coding conventions across projects.',
         'Continuously evaluate and adopt modern technologies to improve development workflows and overall product quality.',
     ],
     technologies: [


### PR DESCRIPTION
Convert the ThemeScript IIFE into a reusable applyTheme() function, remove the unused LIGHT_ACCENTS constant, and invoke applyTheme() on load and after Astro swaps (astro:after-swap) so the theme/accent is reapplied dynamically. Also simplify the vocphone experience's description list by removing two responsibility items (end-to-end project lead and mentoring) to update/shorten the role summary.